### PR TITLE
chore(renovate): correct syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,5 @@
       ],
       "automerge": true
     }
-  }
+  ]
 }


### PR DESCRIPTION
As Renovate will fail to run against the repository.

Renovate will raise an issue for this, but as issues are disabled on the repo, it only appears in logs.